### PR TITLE
Fix CWE-315

### DIFF
--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -1,6 +1,5 @@
 package controllers;
 
-
 import helpers.HashUtils;
 import models.User;
 import play.i18n.Messages;
@@ -13,20 +12,19 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.remove("username");  // ya no usamos "password" en sesión
         login();
     }
 
     public static void authenticate(String username, String password){
         User u = User.loadUser(username);
         if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
+            // Guardamos solo identificador NO sensible
             session.put("username", username);
-            session.put("password", password);
             Application.index();
         }else{
             flash.put("error", Messages.get("Public.login.error.credentials"));
             login();
         }
-
     }
 }


### PR DESCRIPTION
Se corrige la vulnerabilidad CWE‑315: Cleartext Storage of Sensitive Information in a Cookie eliminando el almacenamiento de la contraseña en la cookie de sesión PLAY_SESSION.
​
**Detalles técnicos**

- En app/controllers/Secure.java, el método authenticate guardaba la contraseña en texto claro en la sesión mediante:
_java
session.put("password", password);_

- Esto provoca que la credencial se serialice dentro de la cookie de sesión, exponiéndola si la cookie es robada.

**Cambios realizados**

- Eliminada la línea que almacenaba la contraseña en sesión.
- La sesión conserva únicamente el identificador no sensible del usuario:
_java
session.put("username", username);__

- El método logout se actualiza para limpiar username (o, alternativamente, podría usarse session.clear()).

**Impacto en seguridad**
- Ya no se almacena información sensible en texto claro en la cookie de sesión, mitigando la vulnerabilidad descrita en el Issue #11.
- Se mantiene la funcionalidad de autenticación sin cambios visibles para el usuario.