### PR TITLE
Fix CSRF vulnerability en registro

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -4,18 +4,44 @@ package controllers;
 import helpers.HashUtils;
 import models.User;
 import play.mvc.Controller;
+import java.util.UUID;
 
 public class PublicContentBase extends Controller {
 
-    
-    public static void register(){
-        render();
+    public static void register() {
+    	String csrfToken = UUID.randomUUID().toString();
+    	session.put("csrfToken", csrfToken);
+    	render(csrfToken);
     }
 
-    public static void processRegister(String username, String password, String passwordCheck, String type){
-        User u = new User(username, HashUtils.getMd5(password), type, -1);
-        u.save();
-        registerComplete();
+
+    public static void processRegister(String username, String password,
+                                   String passwordCheck, String type,
+                                   String csrfToken) {
+
+    	String sessionToken = session.get("csrfToken");
+
+    	if (sessionToken == null || csrfToken == null || !sessionToken.equals(csrfToken)) {
+        forbidden("Invalid CSRF token");
+    	}
+
+    	// Invalidar token tras uso
+    	session.remove("csrfToken");
+
+    	// Validaciones mínimas adicionales
+   	if (!password.equals(passwordCheck)) {
+        	error("Passwords do not match");
+    	}
+
+    	// HARDENING: evitar escalada de privilegios
+    	if (!"student".equals(type)) {
+        	forbidden("Invalid user type");
+    	}
+
+    	User u = new User(username, HashUtils.getMd5(password), type, -1);
+    	u.save();
+
+    	registerComplete();
     }
 
     public static void registerComplete(){

--- a/app/views/PublicContentBase/register.html
+++ b/app/views/PublicContentBase/register.html
@@ -45,7 +45,7 @@
 
 #{form @processRegister(), id:'form', name:'reg-form'}
 <h2 class="text-left">&{'Public.register.title'}</h2>
-
+<input type="hidden" name="csrfToken" value="${csrfToken}">
 #{ifErrors}
 <div id="register_error" class="error">${errors[0]}</div>
 #{/ifErrors}


### PR DESCRIPTION
En este trabajo se ha identificado y corregido una vulnerabilidad de tipo **Cross-Site Request Forgery (CSRF)** en el proceso de registro de usuarios de la aplicación web.

El endpoint encargado del registro aceptaba peticiones HTTP POST sin verificar su legitimidad, ya que el formulario de registro no incluía ningún token CSRF y el controlador no realizaba ninguna validación adicional. Esto permitía que un atacante pudiera forzar el envío de peticiones maliciosas desde un sitio externo, provocando la creación de cuentas no autorizadas o la asignación indebida de privilegios.

Para solucionar esta vulnerabilidad, se ha implementado un mecanismo de protección **CSRF basado en un token único por sesión**. Dicho token se genera en el servidor al cargar el formulario de registro, se incluye como campo oculto en el formulario y se valida en el backend antes de procesar la petición. En caso de que el token no exista o no sea válido, la solicitud es rechazada.

Campo oculto en el formulario **Register.html.**
<img width="537" height="101" alt="register" src="https://github.com/user-attachments/assets/ab681d0b-a920-4d87-8f29-6d3e0938d8a3" />

En el metodo **ProcessRegister** se ha añadido un mecanismo de protección CSRF. Para ello, se genera un token CSRF único por sesión, que se envía al formulario de registro como un campo oculto. Cuando el formulario se envía, el método processRegister recibe dicho token y lo compara con el almacenado en la sesión del usuario. Si el token no existe o no coincide, la petición es rechazada y el usuario no se registra. Además, el token CSRF se elimina tras su uso para evitar su reutilización, y se ha reforzado la validación en el servidor para impedir la asignación de roles no permitidos durante el registro.
<img width="471" height="154" alt="public" src="https://github.com/user-attachments/assets/d0b68d65-005a-4b25-8465-dd9a0894288e" />
<img width="719" height="467" alt="process" src="https://github.com/user-attachments/assets/f44b9570-bb82-4e47-9ad0-5205d8b375aa" />

Tras la implementación, se ha realizado una comprobación manual desde el navegador, verificando que:

- El formulario incluye correctamente el token CSRF.
- El registro solo se completa cuando el token válido está presente.
- Las peticiones sin token CSRF son rechazadas por el servidor.

En la siguiente imagen podemos visualizar el token generado desde el navegador:
<img width="963" height="164" alt="Captura de pantalla 2025-12-22 184513" src="https://github.com/user-attachments/assets/897d4f05-9b0f-43e5-bae8-b58b4004c507" />

Con esta corrección soluciona el issue #7  que se mitiga eficazmente la vulnerabilidad CSRF, reforzando la seguridad del proceso de registro y evitando ataques de falsificación de peticiones.
