### PR TITLE
Fix de la vulnerabilidad Contraseñas guardadas en texto plano

### DIFF
--- a/app/controllers/PublicContentBase.java
+++ b/app/controllers/PublicContentBase.java
@@ -13,7 +13,11 @@ public class PublicContentBase extends Controller {
     }
 
     public static void processRegister(String username, String password, String passwordCheck, String type){
-        User u = new User(username, HashUtils.getMd5(password), type, -1);
+        String salt = HashUtils.generateSalt();
+        String hashedPassword = HashUtils.hashPassword(password, salt);
+        
+        User u = new User(username, hashedPassword, type, -1);
+        u.setSalt(salt);
         u.save();
         registerComplete();
     }

--- a/app/controllers/Secure.java
+++ b/app/controllers/Secure.java
@@ -13,20 +13,26 @@ public class Secure extends Controller {
     }
 
     public static void logout(){
-        session.remove("password");
+        session.clear(); // Elimina toda la sesión
         login();
     }
 
-    public static void authenticate(String username, String password){
+
+    public static void authenticate(String username, String password) {
+
         User u = User.loadUser(username);
-        if (u != null && u.getPassword().equals(HashUtils.getMd5(password))){
+
+        if (u != null && HashUtils.verifyPassword(
+                password,
+                u.getPassword(),
+                u.getSalt())) {
+
             session.put("username", username);
-            session.put("password", password);
             Application.index();
-        }else{
+
+        } else {
             flash.put("error", Messages.get("Public.login.error.credentials"));
             login();
         }
-
     }
 }

--- a/app/helpers/HashUtils.java
+++ b/app/helpers/HashUtils.java
@@ -1,23 +1,63 @@
 package helpers;
 
 
-import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
 
 public class HashUtils {
 
-    public static String getMd5(String s){
-        try {
-            MessageDigest m = MessageDigest.getInstance("MD5");
-            m.reset();
-            m.update(s.getBytes());
-            byte[] digest = m.digest();
-            BigInteger bigInt = new BigInteger(1,digest);
-            String hashtext = bigInt.toString(16);
-            while(hashtext.length() < 32){
-                hashtext = "0" + hashtext;
-            }
-        } catch (Exception e) {}
-        return s;
+    private static final int SALT_LENGTH = 16;
+    private static final int ITERATIONS = 150_000;
+
+    //Generamos un salt seguro para los hash
+    public static String generateSalt() {
+        byte[] salt = new byte[SALT_LENGTH];
+        new SecureRandom().nextBytes(salt);
+        return Base64.getEncoder().encodeToString(salt);
     }
+
+    //Ahora hasheamos la contraseña utilizando SHA-256 + salt
+    public static String hashPassword(String password, String salt) {
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = (salt + password).getBytes(StandardCharsets.UTF_8);
+
+                for (int i = 0; i < ITERATIONS; i++) {
+                    hash = digest.digest(hash);
+                }
+
+                return Base64.getEncoder().encodeToString(hash);
+            } catch (Exception e) {
+                throw new IllegalStateException("Error hashing password", e);
+            }
+        }
+
+    // Verifica la contraseña en login
+    public static boolean verifyPassword(
+            String inputPassword,
+            String storedHash,
+            String storedSalt) {
+
+        String inputHash = hashPassword(inputPassword, storedSalt);
+        return constantTimeEquals(storedHash, inputHash);
+    }
+
+    // Comparación en tiempo constante
+    private static boolean constantTimeEquals(String a, String b) {
+        if (a.length() != b.length()) return false;
+        int result = 0;
+        for (int i = 0; i < a.length(); i++) {
+            result |= a.charAt(i) ^ b.charAt(i);
+        }
+        return result == 0;
+    }
+}
+
+@Deprecated
+public static String getMd5(String s) {
+    throw new UnsupportedOperationException(
+        "Insecure method removed. Use hashPassword() instead."
+    );
 }


### PR DESCRIPTION
Con este fix se pretende arreglar la vulnerabilidad donde las contraseñas se guardan y comparan en texto plano (OWASP A02).

Para ello se han realizado los siguientes cambios:

- **Quitar el uso MD5.**
- Implementar el **uso de SHA-256** junto a **salteado por usuario.**
- **Actualizar el flujo de registro** para almacenar los **hashes salteados**.
- Actualizar la lógica de autenticación para **verificar los hashes de las contraseñas.**
- Eliminado el **almacenaje de contraseñas en sesión**.

Con estos cambios nos aseguramos de **prevenir el almacenamiento de contraseñas en texto plano**, cumplir con **OWASP Top 10 A02 (Cryptographic Failures)** y mitigar el riesgo de leak de credenciales.
Los archivos que se han modificado son:

- El objeto "**HashUtils.java**": Implementando un **salt seguro para los hashes y la utilización de SHA-256** en lugar de MD5.
<img width="702" height="708" alt="image" src="https://github.com/user-attachments/assets/bc962573-8cab-44a2-b4a2-a6e951f44a8d" />

Además, se ha añadido al final del código una parte "_Deprecated_" del **uso de MD5** para evitar usos futuros.
<img width="510" height="131" alt="image" src="https://github.com/user-attachments/assets/36bc8028-5a2c-4ee9-98a1-a296ff58ba00" />

- El objeto "**PublicContentBase.java**":  Hemos **eliminado el guardado de texto plano y agregado un salt por usuario** añadiéndolo al hash. De esta forma **se guardará salt + hash**.
<img width="840" height="177" alt="image" src="https://github.com/user-attachments/assets/fc313ccd-c68b-4db9-8c2c-14fa38f1cb17" />

- El objeto "**Secure.java**": **Se recalcula el hash y se compara correctamente sin exposición de la contraseña**.
<img width="569" height="240" alt="image" src="https://github.com/user-attachments/assets/8eebf232-499c-4c86-a60e-968cb765c492" />

De esta forma corregimos la issue https://github.com/Torvel/master-ciberseguridad-web-colaborativa/issues/13 que nuestro compañero encontró anteriormente donde **las contraseñas no estaban seguras en texto plano**.

